### PR TITLE
Sign data with validator key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # validator-keys-tool
 
+[![CircleCI](https://circleci.com/gh/ripple/validator-keys-tool.svg?style=svg)](https://circleci.com/gh/ripple/validator-keys-tool)
+[![Build Status](https://travis-ci.org/ripple/validator-keys-tool.svg?branch=master)](https://travis-ci.org/ripple/validator-keys-tool)
+[![Build status](https://ci.appveyor.com/api/projects/status/dd42bs8pfao8k82p/branch/master?svg=true)](https://ci.appveyor.com/project/ripple/validator-keys-tool)
+[![codecov](https://codecov.io/gh/ripple/validator-keys-tool/branch/master/graph/badge.svg)](https://codecov.io/gh/ripple/validator-keys-tool)
+
 Rippled validator key generation tool
 
 ## Table of contents

--- a/doc/validator-keys-tool-guide.md
+++ b/doc/validator-keys-tool-guide.md
@@ -97,3 +97,18 @@ Sample output:
 Add the `[validator_key_revocation]` value to this validator's config and
 restart rippled. Rename the old key file and generate new [validator keys](#validator-keys) and
 a corresponding [validator token](#validator-token).
+
+## Signing
+
+The `validator-keys` tool can be used to sign arbitrary data with the validator
+key.
+
+```
+  $ validator-keys sign "your data to sign"
+```
+
+Sample output:
+
+```
+  B91B73536235BBA028D344B81DBCBECF19C1E0034AC21FB51C2351A138C9871162F3193D7C41A49FB7AABBC32BC2B116B1D5701807BE462D8800B5AEA4F0550D
+```

--- a/src/ValidatorKeys.cpp
+++ b/src/ValidatorKeys.cpp
@@ -192,9 +192,9 @@ ValidatorKeys::createValidatorToken (
     st[sfPublicKey] = publicKey_;
     st[sfSigningPubKey] = tokenPublic;
 
-    sign(st, HashPrefix::manifest, keyType, tokenSecret);
+    ripple::sign(st, HashPrefix::manifest, keyType, tokenSecret);
 
-    sign(st, HashPrefix::manifest, keyType_, secretKey_,
+    ripple::sign(st, HashPrefix::manifest, keyType_, secretKey_,
         sfMasterSignature);
 
     Serializer s;
@@ -214,7 +214,7 @@ ValidatorKeys::revoke ()
     st[sfSequence] = std::numeric_limits<std::uint32_t>::max ();
     st[sfPublicKey] = publicKey_;
 
-    sign(st, HashPrefix::manifest, keyType_, secretKey_,
+    ripple::sign(st, HashPrefix::manifest, keyType_, secretKey_,
         sfMasterSignature);
 
     Serializer s;
@@ -222,6 +222,12 @@ ValidatorKeys::revoke ()
 
     std::string m (static_cast<char const*> (s.data()), s.size());
     return beast::detail::base64_encode(m);
+}
+
+std::string
+ValidatorKeys::sign (std::string const& data)
+{
+    return strHex(ripple::sign (publicKey_, secretKey_, makeSlice (data)));
 }
 
 } // ripple

--- a/src/ValidatorKeys.h
+++ b/src/ValidatorKeys.h
@@ -106,6 +106,15 @@ public:
     std::string
     revoke ();
 
+    /** Signs string with validator key
+
+    @papam data String to sign
+
+    @return hex-encoded signature
+    */
+    std::string
+    sign (std::string const& data);
+
     /** Returns the public key. */
     PublicKey const&
     publicKey () const

--- a/src/ValidatorKeysTool.h
+++ b/src/ValidatorKeysTool.h
@@ -29,6 +29,9 @@ class path;
 }
 }
 
+std::string const&
+getVersionString ();
+
 void
 createKeyFile (boost::filesystem::path const& keyFile);
 

--- a/src/ValidatorKeysTool.h
+++ b/src/ValidatorKeysTool.h
@@ -30,14 +30,19 @@ class path;
 }
 
 void
-createKeyFile (const boost::filesystem::path& keyFile);
+createKeyFile (boost::filesystem::path const& keyFile);
 
 void
-createToken (const boost::filesystem::path& keyFile);
+createToken (boost::filesystem::path const& keyFile);
 
 void
-createRevocation (const boost::filesystem::path& keyFile);
+createRevocation (boost::filesystem::path const& keyFile);
+
+void
+signData (std::string const& data,
+    boost::filesystem::path const& keyFile);
 
 int
-runCommand (const std::string& command,
-    const boost::filesystem::path& keyFile);
+runCommand (std::string const& command,
+    std::vector <std::string> const& arg,
+    boost::filesystem::path const& keyFile);

--- a/src/test/ValidatorKeysTool_test.cpp
+++ b/src/test/ValidatorKeysTool_test.cpp
@@ -299,6 +299,8 @@ public:
     void
     run() override
     {
+        getVersionString();
+
         testCreateKeyFile ();
         testCreateToken ();
         testCreateRevocation ();


### PR DESCRIPTION
The `sign` command will be used for the new validator domain verification process as well as possible future use cases.