### PR TITLE
namespace beast unit_test under ripple

### DIFF
--- a/src/ValidatorKeysTool.cpp
+++ b/src/ValidatorKeysTool.cpp
@@ -25,7 +25,7 @@
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/beast/core/SemanticVersion.h>
 #include <ripple/beast/unit_test.h>
-#include <beast/unit_test/dstream.hpp>
+#include <ripple/beast/unit_test/dstream.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>


### PR DESCRIPTION
https://github.com/ripple/rippled/pull/4068 will break validator-keys-tool because 
beast headers will be under `ripple` directory.
