### PR TITLE
Improve Visual Studio build check for newer versions

### DIFF
--- a/Builds/CMake/KeysSanity.cmake
+++ b/Builds/CMake/KeysSanity.cmake
@@ -73,10 +73,8 @@ if ("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     "directory from ${CMAKE_CURRENT_SOURCE_DIR} and try building in a separate directory.")
 endif ()
 
-if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio" AND
-    NOT ("${CMAKE_GENERATOR}" MATCHES .*Win64.*))
-  message (FATAL_ERROR
-    "Visual Studio 32-bit build is not supported. Use -G\"${CMAKE_GENERATOR} Win64\"")
+if (MSVC AND CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
+  message (FATAL_ERROR "Visual Studio 32-bit build is not supported.")
 endif ()
 
 if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
This is basically the same change that was included in https://github.com/ripple/rippled/pull/4150

Building with the Visual Studio 19 or 22 cmake generators fails because "Win64" is not included in the name. That's because the naming convention was changed between 17 and 19 to not include the architecture, and the default was changed to 64-bit, so the check can be a lot looser.