### PR TITLE
Change / --> + to fix build failure during rippled build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if (NOT has_parent)
 
     # rippled_tag is cache string and can be overriden when configuring
     # with -Drippled_tag=commit_or_tag in order to pick a specific
-    # rippled version to download. Default tag is develop/master/release as 
+    # rippled version to download. Default tag is develop/master/release as
     # determined by the branch of this project
     if (NOT (_branch STREQUAL "master" OR _branch STREQUAL "release"))
       set (rippled_tag "develop" CACHE STRING
@@ -74,7 +74,7 @@ include(KeysInterface)
 add_executable (validator-keys
   src/ValidatorKeys.cpp
   src/ValidatorKeysTool.cpp
-  ## UNIT TESTS:
+  # UNIT TESTS:
   src/test/ValidatorKeys_test.cpp
   src/test/ValidatorKeysTool_test.cpp)
 target_include_directories (validator-keys PRIVATE src)
@@ -84,6 +84,3 @@ if (has_parent)
   set_target_properties (validator-keys PROPERTIES EXCLUDE_FROM_ALL ON)
   set_target_properties (validator-keys PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD ON)
 endif ()
-
-
-

--- a/src/test/ValidatorKeysTool_test.cpp
+++ b/src/test/ValidatorKeysTool_test.cpp
@@ -59,7 +59,7 @@ private:
 
         std::string const subdir = "test_key_file";
         KeyFileGuard const g (*this, subdir);
-        path const keyFile = subdir / "validator_keys.json";
+        path const keyFile = subdir + "validator_keys.json";
 
         createKeyFile (keyFile);
         BEAST_EXPECT(exists(keyFile));
@@ -90,7 +90,7 @@ private:
 
         std::string const subdir = "test_key_file";
         KeyFileGuard const g (*this, subdir);
-        path const keyFile = subdir / "validator_keys.json";
+        path const keyFile = subdir + "validator_keys.json";
 
         auto testToken = [this](
             path const& keyFile,
@@ -154,7 +154,7 @@ private:
 
         std::string const subdir = "test_key_file";
         KeyFileGuard const g (*this, subdir);
-        path const keyFile = subdir / "validator_keys.json";
+        path const keyFile = subdir + "validator_keys.json";
 
         auto expectedError =
             "Failed to open key file: " + keyFile.string();
@@ -203,7 +203,7 @@ private:
 
         std::string const subdir = "test_key_file";
         KeyFileGuard const g (*this, subdir);
-        path const keyFile = subdir / "validator_keys.json";
+        path const keyFile = subdir + "validator_keys.json";
 
         {
             std::string const expectedError =
@@ -238,7 +238,7 @@ private:
 
         std::string const subdir = "test_key_file";
         KeyFileGuard g (*this, subdir);
-        path const keyFile = subdir / "validator_keys.json";
+        path const keyFile = subdir + "validator_keys.json";
 
         auto testCommand = [this](
             std::string const& command,

--- a/src/test/ValidatorKeys_test.cpp
+++ b/src/test/ValidatorKeys_test.cpp
@@ -62,7 +62,7 @@ private:
         using namespace boost::filesystem;
 
         std::string const subdir = "test_key_file";
-        path const keyFile = subdir / "validator_keys.json";
+        path const keyFile = subdir + "validator_keys.json";
 
         for (auto const keyType : keyTypes)
         {
@@ -305,7 +305,7 @@ private:
 
         {
             std::string const subdir = "test_key_file";
-            path const keyFile = subdir / "validator_keys.json";
+            path const keyFile = subdir + "validator_keys.json";
             KeyFileGuard g (*this, subdir);
 
             keys.writeToFile (keyFile);
@@ -341,7 +341,7 @@ private:
             // Create key file directory
             std::string const subdir = "test_key_file";
             path const keyFile =
-                subdir / "directories/to/create/validator_keys.json";
+                subdir + "directories/to/create/validator_keys.json";
             KeyFileGuard g (*this, subdir);
 
             keys.writeToFile (keyFile);
@@ -355,7 +355,7 @@ private:
             std::string const subdir = "test_key_file";
             KeyFileGuard g (*this, subdir);
 
-            path const badKeyFile = subdir / ".";
+            path const badKeyFile = subdir + ".";
             auto expectedError = "Cannot open key file: " + badKeyFile.string();
             std::string error;
             try {
@@ -366,7 +366,7 @@ private:
             BEAST_EXPECT(error == expectedError);
 
             // Fail if parent directory is existing file
-            path const keyFile = subdir / "validator_keys.json";
+            path const keyFile = subdir + "validator_keys.json";
             keys.writeToFile (keyFile);
             path const conflictingPath =
                 keyFile / "validators_keys.json";


### PR DESCRIPTION
Fixes errors of:
```

In file included from ../../src/ripple/basics/IOUAmount.h:24,
                 from ../../src/ripple/protocol/STAmount.h:24,
                 from ../../src/ripple/protocol/STObject.h:30,
                 from ../../src/ripple/protocol/STExchange.h:30,
                 from ../../src/ripple/protocol/PublicKey.h:25,
                 from ../../src/ripple/protocol/SecretKey.h:26,
                 from _deps/validator_keys_src-src/.nih_c/ninja/GNU_11.1.0/Release/validator_keys_src-src/src/ValidatorKeys.h:22,
                 from _deps/validator_keys_src-src/.nih_c/ninja/GNU_11.1.0/Release/validator_keys_src-src/src/test/ValidatorKeys_test.cpp:20:
../../src/ripple/basics/Number.h:293:1: note: candidate: 'ripple::Number ripple::operator/(const ripple::Number&, const ripple::Number&)'
  293 | operator/(Number const& x, Number const& y)
      | ^~~~~~~~
../../src/ripple/basics/Number.h:293:25: note:   no known conversion for argument 1 from 'const string' {aka 'const std::__cxx11::basic_string<char>'} to 'const ripple::Number&'
  293 | operator/(Number const& x, Number const& y)
      |           ~~~~~~~~~~~~~~^
```