### PR TITLE
Fix failing unit tests

### DIFF
--- a/src/test/ValidatorKeysTool_test.cpp
+++ b/src/test/ValidatorKeysTool_test.cpp
@@ -57,8 +57,8 @@ private:
 
         using namespace boost::filesystem;
 
-        std::string const subdir = "test_key_file";
-        KeyFileGuard const g (*this, subdir);
+        path const subdir = "test_key_file";
+        KeyFileGuard const g (*this, subdir.string());
         path const keyFile = subdir / "validator_keys.json";
 
         createKeyFile (keyFile);
@@ -88,8 +88,8 @@ private:
 
         using namespace boost::filesystem;
 
-        std::string const subdir = "test_key_file";
-        KeyFileGuard const g (*this, subdir);
+        path const subdir = "test_key_file";
+        KeyFileGuard const g (*this, subdir.string());
         path const keyFile = subdir / "validator_keys.json";
 
         auto testToken = [this](
@@ -152,8 +152,8 @@ private:
 
         using namespace boost::filesystem;
 
-        std::string const subdir = "test_key_file";
-        KeyFileGuard const g (*this, subdir);
+        path const subdir = "test_key_file";
+        KeyFileGuard const g (*this, subdir.string());
         path const keyFile = subdir / "validator_keys.json";
 
         auto expectedError =
@@ -201,8 +201,8 @@ private:
 
         std::string const data = "data to sign";
 
-        std::string const subdir = "test_key_file";
-        KeyFileGuard const g (*this, subdir);
+        path const subdir = "test_key_file";
+        KeyFileGuard const g (*this, subdir.string());
         path const keyFile = subdir / "validator_keys.json";
 
         {
@@ -236,8 +236,8 @@ private:
 
         using namespace boost::filesystem;
 
-        std::string const subdir = "test_key_file";
-        KeyFileGuard g (*this, subdir);
+        path const subdir = "test_key_file";
+        KeyFileGuard g (*this, subdir.string());
         path const keyFile = subdir / "validator_keys.json";
 
         auto testCommand = [this](

--- a/src/test/ValidatorKeys_test.cpp
+++ b/src/test/ValidatorKeys_test.cpp
@@ -61,14 +61,14 @@ private:
 
         using namespace boost::filesystem;
 
-        std::string const subdir = "test_key_file";
+        path const subdir = "test_key_file";
         path const keyFile = subdir / "validator_keys.json";
 
         for (auto const keyType : keyTypes)
         {
             ValidatorKeys const keys (keyType);
 
-            KeyFileGuard const g (*this, subdir);
+            KeyFileGuard const g (*this, subdir.string());
 
             keys.writeToFile (keyFile);
             BEAST_EXPECT (exists (keyFile));
@@ -78,7 +78,7 @@ private:
         }
         {
             // Require expected fields
-            KeyFileGuard g (*this, subdir);
+            KeyFileGuard g (*this, subdir.string());
 
             auto expectedError =
                 "Failed to open key file: " + keyFile.string();
@@ -304,9 +304,9 @@ private:
         ValidatorKeys keys (keyType);
 
         {
-            std::string const subdir = "test_key_file";
+            path const subdir = "test_key_file";
             path const keyFile = subdir / "validator_keys.json";
-            KeyFileGuard g (*this, subdir);
+            KeyFileGuard g (*this, subdir.string());
 
             keys.writeToFile (keyFile);
             BEAST_EXPECT(exists (keyFile));
@@ -339,10 +339,10 @@ private:
         }
         {
             // Create key file directory
-            std::string const subdir = "test_key_file";
+            path const subdir = "test_key_file";
             path const keyFile =
                 subdir / "directories/to/create/validator_keys.json";
-            KeyFileGuard g (*this, subdir);
+            KeyFileGuard g (*this, subdir.string());
 
             keys.writeToFile (keyFile);
             BEAST_EXPECT(exists (keyFile));
@@ -352,8 +352,8 @@ private:
         }
         {
             // Fail if file cannot be opened for write
-            std::string const subdir = "test_key_file";
-            KeyFileGuard g (*this, subdir);
+            path const subdir = "test_key_file";
+            KeyFileGuard g (*this, subdir.string());
 
             path const badKeyFile = subdir / ".";
             auto expectedError = "Cannot open key file: " + badKeyFile.string();


### PR DESCRIPTION
Last change fixed the build but then unit tests failed to properly deal with paths to the keyfile.