### PR TITLE
Fix build and unit tests with correct combo of /, + and types

### DIFF
--- a/src/test/ValidatorKeys_test.cpp
+++ b/src/test/ValidatorKeys_test.cpp
@@ -355,7 +355,7 @@ private:
             path const subdir = "test_key_file";
             KeyFileGuard g (*this, subdir.string());
 
-            path const badKeyFile = subdir + ".";
+            path const badKeyFile = subdir / ".";
             auto expectedError = "Cannot open key file: " + badKeyFile.string();
             std::string error;
             try {
@@ -366,7 +366,7 @@ private:
             BEAST_EXPECT(error == expectedError);
 
             // Fail if parent directory is existing file
-            path const keyFile = subdir + "validator_keys.json";
+            path const keyFile = subdir / "validator_keys.json";
             keys.writeToFile (keyFile);
             path const conflictingPath =
                 keyFile / "validators_keys.json";


### PR DESCRIPTION
```
[100%] Built target validator-keys
root@e5b26f56dc0d:/ripd# ./build/val_test/validator-keys/validator-keys --version
validator-keys version 0.3.2
root@e5b26f56dc0d:/ripd# ./build/val_test/validator-keys/validator-keys --unittest
ripple.keys.ValidatorKeys Make Validator Keys
ripple.keys.ValidatorKeys Create Validator Token
ripple.keys.ValidatorKeys Revoke
ripple.keys.ValidatorKeys Sign
ripple.keys.ValidatorKeys Write to File
ripple.keys.ValidatorKeysTool Create Key File
ripple.keys.ValidatorKeysTool Create Token
ripple.keys.ValidatorKeysTool Create Revocation
ripple.keys.ValidatorKeysTool Sign
ripple.keys.ValidatorKeysTool Run Command
22ms, 2 suites, 10 cases, 107 tests total, 0 failures

```