### PR TITLE
[TRIVIAL] Change variable ordering to prevent compiler warning:

### DIFF
--- a/src/ValidatorKeys.h
+++ b/src/ValidatorKeys.h
@@ -59,11 +59,11 @@ private:
           : publicKey(p.first), secretKey(p.second) {}
     };
 
-    Keys keys_;
     std::vector<std::uint8_t> manifest_;
     std::uint32_t tokenSequence_;
     bool revoked_;
     std::string domain_;
+    Keys keys_;
 
 public:
     explicit


### PR DESCRIPTION
This warning causes an error when building with `-Werror`, which happens for me in particular when building from the `rippled` repo with the `cmake -Dwerr=ON` configuration, and building `cmake --build . --target validator-keys`.

You can reproduce the issue from `rippled` by running
```
git checkout develop
cmake -Dvalidator-keys=ON [...] <build dir>
cmake --build <build dir> --target validator-keys
```