### PR TITLE
Add support for external signing

### DIFF
--- a/src/ValidatorKeys.cpp
+++ b/src/ValidatorKeys.cpp
@@ -25,9 +25,11 @@
 #include <xrpl/json/json_reader.h>
 #include <xrpl/json/to_string.h>
 #include <xrpl/protocol/HashPrefix.h>
+#include <xrpl/protocol/Serializer.h>
 #include <xrpl/protocol/Sign.h>
 
 #include <boost/algorithm/clamp.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 
@@ -47,9 +49,9 @@ ValidatorToken::toString() const
 
 ValidatorKeys::ValidatorKeys(KeyType const& keyType)
     : keyType_(keyType)
+    , keys_(generateKeyPair(keyType_, randomSeed()))
     , tokenSequence_(0)
     , revoked_(false)
-    , keys_(generateKeyPair(keyType_, randomSeed()))
 {
 }
 
@@ -59,9 +61,21 @@ ValidatorKeys::ValidatorKeys(
     std::uint32_t tokenSequence,
     bool revoked)
     : keyType_(keyType)
+    , keys_({derivePublicKey(keyType_, secretKey), secretKey})
     , tokenSequence_(tokenSequence)
     , revoked_(revoked)
-    , keys_({derivePublicKey(keyType_, secretKey), secretKey})
+{
+}
+
+ValidatorKeys::ValidatorKeys(
+    KeyType const& keyType,
+    PublicKey const& publicKey,
+    std::uint32_t tokenSequence,
+    bool revoked)
+    : keyType_(keyType)
+    , keys_(publicKey)
+    , tokenSequence_(tokenSequence)
+    , revoked_(revoked)
 {
 }
 
@@ -107,13 +121,33 @@ ValidatorKeys::make_ValidatorKeys(boost::filesystem::path const& keyFile)
     auto const secret = parseBase58<SecretKey>(
         TokenType::NodePrivate, jKeys["secret_key"].asString());
 
-    if (!secret)
-    {
-        throw std::runtime_error(
-            "Key file '" + keyFile.string() +
-            "' contains invalid \"secret_key\" field: " +
-            jKeys["secret_key"].toStyledString());
-    }
+    auto const pubKey = [&]() -> std::optional<PublicKey> {
+        if (jKeys["secret_key"].asString() == "external")
+        {
+            if (!jKeys.isMember("public_key"))
+            {
+                throw std::runtime_error(
+                    "Key file '" + keyFile.string() +
+                    "' is missing \"public_key\" field");
+            }
+            auto const pubKey = parseBase58<PublicKey>(
+                TokenType::NodePublic, jKeys["public_key"].asString());
+            if (!pubKey)
+                throw std::runtime_error(
+                    "Key file '" + keyFile.string() +
+                    "' contains invalid \"public_key\" field: " +
+                    jKeys["public_key"].toStyledString());
+            return pubKey;
+        }
+        else if (!secret)
+        {
+            throw std::runtime_error(
+                "Key file '" + keyFile.string() +
+                "' contains invalid \"secret_key\" field: " +
+                jKeys["secret_key"].toStyledString());
+        }
+        return std::nullopt;
+    }();
 
     std::uint32_t tokenSequence;
     try
@@ -137,8 +171,17 @@ ValidatorKeys::make_ValidatorKeys(boost::filesystem::path const& keyFile)
             "' contains invalid \"revoked\" field: " +
             jKeys["revoked"].toStyledString());
 
-    ValidatorKeys vk(
-        *keyType, *secret, tokenSequence, jKeys["revoked"].asBool());
+    ValidatorKeys vk = [&]() {
+        if (secret)
+            return ValidatorKeys(
+                *keyType, *secret, tokenSequence, jKeys["revoked"].asBool());
+        else
+        {
+            assert(*keyType == *publicKeyType(*pubKey));
+            return ValidatorKeys(
+                *keyType, *pubKey, tokenSequence, jKeys["revoked"].asBool());
+        }
+    }();
 
     if (jKeys.isMember("domain"))
     {
@@ -172,6 +215,40 @@ ValidatorKeys::make_ValidatorKeys(boost::filesystem::path const& keyFile)
         std::copy(ret->begin(), ret->end(), std::back_inserter(vk.manifest_));
     }
 
+    if (jKeys.isMember("pending_token_secret"))
+    {
+        if (!jKeys["pending_token_secret"].isString())
+            throw std::runtime_error(
+                "Key file '" + keyFile.string() +
+                "' contains invalid \"pending_token_secret\" field: " +
+                jKeys["pending_token_secret"].toStyledString());
+
+        vk.pendingTokenSecret_ = parseBase58<SecretKey>(
+            TokenType::NodePrivate, jKeys["pending_token_secret"].asString());
+
+        if (!vk.pendingTokenSecret_)
+        {
+            throw std::runtime_error(
+                "Key file '" + keyFile.string() +
+                "' contains invalid \"pending_token_secret\" field: " +
+                jKeys["pending_manifest"].toStyledString());
+        }
+    }
+
+    if (jKeys.isMember("pending_key_type"))
+    {
+        auto const keyType =
+            keyTypeFromString(jKeys["pending_key_type"].asString());
+        if (!keyType)
+        {
+            throw std::runtime_error(
+                "Key file '" + keyFile.string() +
+                "' contains invalid \"pending_key_type\" field: " +
+                jKeys["key_type"].toStyledString());
+        }
+        vk.pendingKeyType_ = keyType;
+    }
+
     return vk;
 }
 
@@ -183,13 +260,20 @@ ValidatorKeys::writeToFile(boost::filesystem::path const& keyFile) const
     Json::Value jv;
     jv["key_type"] = to_string(keyType_);
     jv["public_key"] = toBase58(TokenType::NodePublic, keys_.publicKey);
-    jv["secret_key"] = toBase58(TokenType::NodePrivate, keys_.secretKey);
+    jv["secret_key"] = keys_.secretKey
+        ? toBase58(TokenType::NodePrivate, *keys_.secretKey)
+        : "external";
     jv["token_sequence"] = Json::UInt(tokenSequence_);
     jv["revoked"] = revoked_;
     if (!domain_.empty())
         jv["domain"] = domain_;
     if (!manifest_.empty())
         jv["manifest"] = strHex(makeSlice(manifest_));
+    if (pendingTokenSecret_)
+        jv["pending_token_secret"] =
+            toBase58(TokenType::NodePrivate, *pendingTokenSecret_);
+    if (pendingKeyType_)
+        jv["pending_key_type"] = to_string(*pendingKeyType_);
 
     if (!keyFile.parent_path().empty())
     {
@@ -209,6 +293,57 @@ ValidatorKeys::writeToFile(boost::filesystem::path const& keyFile) const
     o << jv.toStyledString();
 }
 
+void
+ValidatorKeys::verifyManifest() const
+{
+    STObject st(sfGeneric);
+    SerialIter sit(manifest_.data(), manifest_.size());
+    st.set(sit);
+
+    auto fail = []() {
+        throw std::runtime_error("Manifest is not properly signed");
+    };
+    auto const tpk = get<PublicKey>(st, sfSigningPubKey);
+    if (revoked() && tpk)
+        fail();
+
+    if (!revoked() && (!tpk || !verify(st, HashPrefix::manifest, *tpk)))
+        fail();
+
+    auto const pk = get<PublicKey>(st, sfPublicKey);
+    if (!pk || !verify(st, HashPrefix::manifest, *pk, sfMasterSignature))
+        fail();
+}
+
+// Helper functions
+[[nodiscard]] STObject
+generatePartialManifest(
+    uint32_t sequence,
+    PublicKey const& masterPubKey,
+    PublicKey const& signingPubKey,
+    std::string const& domain)
+{
+    STObject st(sfGeneric);
+    st[sfSequence] = sequence;
+    st[sfPublicKey] = masterPubKey;
+    st[sfSigningPubKey] = signingPubKey;
+
+    if (!domain.empty())
+        st[sfDomain] = makeSlice(domain);
+
+    return st;
+}
+
+[[nodiscard]] STObject
+generatePartialRevocation(PublicKey const& masterPubKey)
+{
+    STObject st(sfGeneric);
+    st[sfSequence] = std::numeric_limits<std::uint32_t>::max();
+    st[sfPublicKey] = masterPubKey;
+
+    return st;
+}
+
 boost::optional<ValidatorToken>
 ValidatorKeys::createValidatorToken(KeyType const& keyType)
 {
@@ -216,29 +351,79 @@ ValidatorKeys::createValidatorToken(KeyType const& keyType)
         std::numeric_limits<std::uint32_t>::max() - 1 <= tokenSequence_)
         return boost::none;
 
+    // Invalid secret key
+    if (!keys_.secretKey)
+        throw std::runtime_error(
+            "This key file cannot be used to sign tokens.");
+
     ++tokenSequence_;
 
     auto const tokenSecret = generateSecretKey(keyType, randomSeed());
     auto const tokenPublic = derivePublicKey(keyType, tokenSecret);
 
-    STObject st(sfGeneric);
-    st[sfSequence] = tokenSequence_;
-    st[sfPublicKey] = keys_.publicKey;
-    st[sfSigningPubKey] = tokenPublic;
-
-    if (!domain_.empty())
-        st[sfDomain] = makeSlice(domain_);
+    STObject st = generatePartialManifest(
+        tokenSequence_, keys_.publicKey, tokenPublic, domain_);
 
     ripple::sign(st, HashPrefix::manifest, keyType, tokenSecret);
     ripple::sign(
-        st, HashPrefix::manifest, keyType_, keys_.secretKey, sfMasterSignature);
+        st,
+        HashPrefix::manifest,
+        keyType_,
+        *keys_.secretKey,
+        sfMasterSignature);
+
+    setManifest(st);
+
+    return ValidatorToken{
+        ripple::base64_encode(manifest_.data(), manifest_.size()), tokenSecret};
+}
+
+boost::optional<std::string>
+ValidatorKeys::startValidatorToken(KeyType const& keyType) const
+{
+    if (revoked() ||
+        std::numeric_limits<std::uint32_t>::max() - 1 <= tokenSequence_)
+        return boost::none;
+
+    auto const tokenSecret = generateSecretKey(keyType, randomSeed());
+    auto const tokenPublic = derivePublicKey(keyType, tokenSecret);
+
+    // Generate the next manifest with the next sequence number, but
+    // don't update until it's been signed
+    STObject st = generatePartialManifest(
+        tokenSequence_ + 1, keys_.publicKey, tokenPublic, domain_);
 
     Serializer s;
-    st.add(s);
+    s.add32(HashPrefix::manifest);
+    st.addWithoutSigningFields(s);
 
-    manifest_.clear();
-    manifest_.reserve(s.size());
-    std::copy(s.begin(), s.end(), std::back_inserter(manifest_));
+    pendingTokenSecret_ = tokenSecret;
+    pendingKeyType_ = keyType;
+
+    return strHex(s.peekData());
+}
+
+boost::optional<ValidatorToken>
+ValidatorKeys::finishToken(Blob const& masterSig)
+{
+    if (revoked())
+        return boost::none;
+
+    if (!pendingTokenSecret_ || !pendingKeyType_)
+        throw std::runtime_error("No pending token to finish");
+
+    ++tokenSequence_;
+
+    auto const tokenSecret = *pendingTokenSecret_;
+    auto const tokenPublic = derivePublicKey(*pendingKeyType_, tokenSecret);
+
+    STObject st = generatePartialManifest(
+        tokenSequence_, keys_.publicKey, tokenPublic, domain_);
+
+    ripple::sign(st, HashPrefix::manifest, *pendingKeyType_, tokenSecret);
+    st[sfMasterSignature] = makeSlice(masterSig);
+
+    setManifest(st);
 
     return ValidatorToken{
         ripple::base64_encode(manifest_.data(), manifest_.size()), tokenSecret};
@@ -247,15 +432,61 @@ ValidatorKeys::createValidatorToken(KeyType const& keyType)
 std::string
 ValidatorKeys::revoke()
 {
+    // Invalid secret key
+    if (!keys_.secretKey)
+        throw std::runtime_error(
+            "This key file cannot be used to sign tokens.");
+
     revoked_ = true;
 
-    STObject st(sfGeneric);
-    st[sfSequence] = std::numeric_limits<std::uint32_t>::max();
-    st[sfPublicKey] = keys_.publicKey;
+    STObject st = generatePartialRevocation(keys_.publicKey);
 
     ripple::sign(
-        st, HashPrefix::manifest, keyType_, keys_.secretKey, sfMasterSignature);
+        st,
+        HashPrefix::manifest,
+        keyType_,
+        *keys_.secretKey,
+        sfMasterSignature);
 
+    setManifest(st);
+
+    return ripple::base64_encode(manifest_.data(), manifest_.size());
+}
+
+std::string
+ValidatorKeys::startRevoke() const
+{
+    // Generate the revocation manifest, but
+    // don't update until it's been signed
+    STObject st = generatePartialRevocation(keys_.publicKey);
+
+    Serializer s;
+    s.add32(HashPrefix::manifest);
+    st.addWithoutSigningFields(s);
+
+    pendingTokenSecret_.reset();
+    pendingKeyType_.reset();
+
+    return strHex(s.peekData());
+}
+
+std::string
+ValidatorKeys::finishRevoke(Blob const& masterSig)
+{
+    revoked_ = true;
+
+    STObject st = generatePartialRevocation(keys_.publicKey);
+
+    st[sfMasterSignature] = makeSlice(masterSig);
+
+    setManifest(st);
+
+    return ripple::base64_encode(manifest_.data(), manifest_.size());
+}
+
+void
+ValidatorKeys::setManifest(STObject const& st)
+{
     Serializer s;
     st.add(s);
 
@@ -263,14 +494,36 @@ ValidatorKeys::revoke()
     manifest_.reserve(s.size());
     std::copy(s.begin(), s.end(), std::back_inserter(manifest_));
 
-    return ripple::base64_encode(manifest_.data(), manifest_.size());
+    verifyManifest();
+
+    pendingTokenSecret_.reset();
+    pendingKeyType_.reset();
 }
 
 std::string
 ValidatorKeys::sign(std::string const& data) const
 {
+    // Invalid secret key
+    if (!keys_.secretKey)
+        throw std::runtime_error("This key file cannot be used to sign.");
+
     return strHex(
-        ripple::sign(keys_.publicKey, keys_.secretKey, makeSlice(data)));
+        ripple::sign(keys_.publicKey, *keys_.secretKey, makeSlice(data)));
+}
+
+std::string
+ValidatorKeys::signHex(std::string data) const
+{
+    // Invalid secret key
+    if (!keys_.secretKey)
+        throw std::runtime_error("This key file cannot be used to sign.");
+
+    boost::algorithm::trim(data);
+    auto const blob = strUnHex(data);
+    if (!blob)
+        throw std::runtime_error("Could not decode hex string: " + data);
+    return strHex(
+        ripple::sign(keys_.publicKey, *keys_.secretKey, makeSlice(*blob)));
 }
 
 void

--- a/src/ValidatorKeysTool.h
+++ b/src/ValidatorKeysTool.h
@@ -40,8 +40,32 @@ createToken(boost::filesystem::path const& keyFile);
 void
 createRevocation(boost::filesystem::path const& keyFile);
 
+/*****************************************/
+/* External signing support              */
+void
+createExternal(std::string const& data, boost::filesystem::path const& keyFile);
+
+void
+startToken(boost::filesystem::path const& keyFile);
+
+void
+finishToken(std::string const& data, boost::filesystem::path const& keyFile);
+
+void
+startRevocation(boost::filesystem::path const& keyFile);
+
+void
+finishRevocation(
+    std::string const& data,
+    boost::filesystem::path const& keyFile);
+
+/*****************************************/
+
 void
 signData(std::string const& data, boost::filesystem::path const& keyFile);
+
+void
+signHexData(std::string const& data, boost::filesystem::path const& keyFile);
 
 int
 runCommand(

--- a/src/test/ValidatorKeysTool_test.cpp
+++ b/src/test/ValidatorKeysTool_test.cpp
@@ -22,6 +22,7 @@
 
 #include <test/KeyFileGuard.h>
 
+#include <xrpl/basics/base64.h>
 #include <xrpl/protocol/SecretKey.h>
 
 namespace ripple {
@@ -31,22 +32,36 @@ namespace tests {
 class ValidatorKeysTool_test : public beast::unit_test::suite
 {
 private:
-    // Allow cout to be redirected.  Destructor restores old cout streambuf.
-    class CoutRedirect
+    // Allow a stream to be redirected. Destructor restores old streambuf.
+    class Redirect
     {
     public:
-        CoutRedirect(std::stringstream& sStream)
-            : old_(std::cout.rdbuf(sStream.rdbuf()))
+        Redirect(std::ostream& stream, std::stringstream& sStream)
+            : stream_(stream), old_(stream_.rdbuf(sStream.rdbuf()))
+        {
+        }
+
+        virtual ~Redirect()
+        {
+            stream_.rdbuf(old_);
+        }
+
+    private:
+        std::ostream& stream_;
+        std::streambuf* const old_;
+    };
+
+    // Allow cout to be redirected.  Destructor restores old cout streambuf.
+    class CoutRedirect : public Redirect
+    {
+    public:
+        CoutRedirect(std::stringstream& sStream) : Redirect(std::cout, sStream)
         {
         }
 
         ~CoutRedirect()
         {
-            std::cout.rdbuf(old_);
         }
-
-    private:
-        std::streambuf* const old_;
     };
 
     void
@@ -72,6 +87,7 @@ private:
         try
         {
             createKeyFile(keyFile);
+            fail();
         }
         catch (std::exception const& e)
         {
@@ -161,6 +177,7 @@ private:
         try
         {
             createRevocation(keyFile);
+            fail();
         }
         catch (std::runtime_error& e)
         {
@@ -173,6 +190,360 @@ private:
 
         createRevocation(keyFile);
         createRevocation(keyFile);
+    }
+
+    void
+    testCreateKeyFileExternal()
+    {
+        testcase("Create Key File External");
+
+        std::stringstream coutCapture;
+        CoutRedirect coutRedirect{coutCapture};
+
+        using namespace boost::filesystem;
+
+        path const subdir = "test_key_file";
+        path const keyFile = subdir / "validator_keys.json";
+
+        // The externalKey will contain a secret key, and be used
+        // to simulate the actions of an actual external signing device
+        // or process. Note that it is const and not written to disk.
+        ValidatorKeys const externalKey(KeyType::ed25519);
+
+        auto testCreate = [this, &subdir, &keyFile](
+                              std::string pubKey,
+                              std::string const& expectedError) {
+            KeyFileGuard const g(*this, subdir.string());
+
+            try
+            {
+                createExternal(pubKey, keyFile);
+                BEAST_EXPECT(expectedError.empty());
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() == expectedError);
+            }
+        };
+        // Test a few different ways to create the file, and remove the file in
+        // between
+        {
+            std::string const pubKey(strHex(externalKey.publicKey()));
+            std::string const expectedError;
+
+            testCreate(pubKey, expectedError);
+        }
+        {
+            auto const& key = externalKey.publicKey();
+            std::string const pubKey(base64_encode(key.data(), key.size()));
+            std::string const expectedError;
+
+            testCreate(pubKey, expectedError);
+        }
+        {
+            std::string badPubKey(strHex(externalKey.publicKey()));
+            badPubKey.insert(badPubKey.size() / 2, "n");
+            std::string const expectedError =
+                "Unable to parse public key: " + badPubKey;
+
+            testCreate(badPubKey, expectedError);
+        }
+        {
+            std::string const badPubKey = "abcd";
+            std::string const expectedError =
+                "Unable to parse public key: " + badPubKey;
+
+            testCreate(badPubKey, expectedError);
+        }
+
+        // Use one file for the remainder of the tests
+        KeyFileGuard const g(*this, subdir.string());
+
+        std::string const pubKey(
+            toBase58(TokenType::NodePublic, externalKey.publicKey()));
+
+        createExternal(pubKey, keyFile);
+
+        BEAST_EXPECT(exists(keyFile));
+
+        std::string const expectedError =
+            "Refusing to overwrite existing key file: " + keyFile.string();
+        std::string error;
+        try
+        {
+            createExternal(pubKey, keyFile);
+            fail();
+        }
+        catch (std::exception const& e)
+        {
+            error = e.what();
+        }
+        BEAST_EXPECT(error == expectedError);
+    }
+
+    void
+    testCreateTokenExternal()
+    {
+        testcase("Create Token External");
+
+        std::stringstream coutCapture;
+        CoutRedirect coutRedirect{coutCapture};
+
+        using namespace boost::filesystem;
+
+        path const subdir = "test_key_file";
+        KeyFileGuard const g(*this, subdir.string());
+        path const keyFile = subdir / "validator_keys.json";
+
+        // The external key will contain a secret key, and be used
+        // to simulate the actions of an actual external signing device
+        // or process. Note that it is const.
+        KeyType const externalKeyType = KeyType::ed25519;
+        ValidatorKeys const externalKey(externalKeyType);
+        std::string const pubKey(
+            toBase58(TokenType::NodePublic, externalKey.publicKey()));
+
+        auto testStart =
+            [this](path const& keyFile, std::string const& expectedError) {
+                std::stringstream capture;
+                CoutRedirect coutRedirect{capture};
+                try
+                {
+                    startToken(keyFile);
+                    BEAST_EXPECT(expectedError.empty());
+                    return capture.str();
+                }
+                catch (std::exception const& e)
+                {
+                    BEAST_EXPECT(e.what() == expectedError);
+                }
+                return std::string();
+            };
+
+        auto testFinish = [this](
+                              std::string const& sig,
+                              path const& keyFile,
+                              std::string const& expectedError) {
+            try
+            {
+                finishToken(sig, keyFile);
+                BEAST_EXPECT(expectedError.empty());
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() == expectedError);
+            }
+        };
+
+        {
+            std::string const expectedError =
+                "Failed to open key file: " + keyFile.string();
+            BEAST_EXPECT(testStart(keyFile, expectedError).empty());
+        }
+
+        createExternal(pubKey, keyFile);
+
+        std::string const noError = "";
+        {
+            auto const start = testStart(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = externalKey.signHex(start);
+            testFinish(sig, keyFile, noError);
+        }
+        {
+            auto const start = testStart(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = [&]() {
+                auto sigBlob = strUnHex(externalKey.signHex(start));
+                if (BEAST_EXPECT(sigBlob))
+                    return base64_encode(sigBlob->data(), sigBlob->size());
+                return base64_encode("fail");
+            }();
+
+            testFinish(sig, keyFile, noError);
+        }
+        {
+            std::string const expectedError = "Manifest is not properly signed";
+            auto const start = testStart(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = externalKey.sign("foo");
+            testFinish(sig, keyFile, expectedError);
+        }
+        {
+            std::string const expectedError = "Invalid master signature";
+            auto const start = testStart(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = "bad signature";
+            testFinish(sig, keyFile, expectedError);
+        }
+        {
+            {
+                // Need to ensure any pending token is gone. Best
+                // way to do that is to generate one successfully
+                auto const start = testStart(keyFile, noError);
+                BEAST_EXPECT(!start.empty());
+                auto const sig = externalKey.signHex(start);
+                testFinish(sig, keyFile, noError);
+            }
+
+            std::string const expectedError = "No pending token to finish";
+            auto const sig = externalKey.sign("foo");
+            testFinish(sig, keyFile, expectedError);
+        }
+        {
+            auto keys = ValidatorKeys(
+                externalKeyType,
+                externalKey.publicKey(),
+                std::numeric_limits<std::uint32_t>::max() - 1);
+
+            keys.writeToFile(keyFile);
+            std::string const expectedError =
+                "Maximum number of tokens have already been generated.\n"
+                "Revoke validator keys if previous token has been compromised.";
+            BEAST_EXPECT(testStart(keyFile, expectedError).empty());
+        }
+        {
+            // Create the file revoked
+            auto keys = ValidatorKeys(
+                externalKeyType, externalKey.publicKey(), 42, true);
+
+            keys.writeToFile(keyFile);
+            std::string const expectedError =
+                "Validator keys have been revoked.";
+            BEAST_EXPECT(testStart(keyFile, expectedError).empty());
+        }
+    }
+
+    void
+    testCreateRevocationExternal()
+    {
+        testcase("Create Revocation External");
+
+        std::stringstream coutCapture;
+        CoutRedirect coutRedirect{coutCapture};
+
+        using namespace boost::filesystem;
+
+        path const subdir = "test_key_file";
+        KeyFileGuard const g(*this, subdir.string());
+        path const keyFile = subdir / "validator_keys.json";
+
+        // The external key will contain a secret key, and be used
+        // to simulate the actions of an actual external signing device
+        // or process. Note that it is const.
+        ValidatorKeys const externalKey(KeyType::ed25519);
+        std::string const pubKey(
+            toBase58(TokenType::NodePublic, externalKey.publicKey()));
+
+        auto testStartRevoke = [this](
+                                   path const& keyFile,
+                                   std::string const& expectedError,
+                                   bool expectRevoked = true) {
+            std::stringstream capture;
+            std::stringstream errCapture;
+            CoutRedirect coutRedirect{capture};
+            Redirect cerrRedirect{std::cerr, errCapture};
+            try
+            {
+                startRevocation(keyFile);
+                BEAST_EXPECT(expectedError.empty());
+                if (expectRevoked)
+                    BEAST_EXPECT(
+                        errCapture.str() ==
+                        "WARNING: Validator keys have already been "
+                        "revoked!\n\n");
+                else
+                    BEAST_EXPECT(
+                        errCapture.str() ==
+                        "WARNING: This will revoke your validator keys!\n\n");
+
+                return capture.str();
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() == expectedError);
+            }
+            return std::string();
+        };
+
+        auto testFinishRevoke = [this](
+                                    std::string const& sig,
+                                    path const& keyFile,
+                                    std::string const& expectedError) {
+            try
+            {
+                finishRevocation(sig, keyFile);
+                BEAST_EXPECT(expectedError.empty());
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() == expectedError);
+            }
+        };
+
+        std::string const noError = "";
+        {
+            auto const expectedError =
+                "Failed to open key file: " + keyFile.string();
+            testStartRevoke(keyFile, expectedError);
+        }
+
+        createExternal(pubKey, keyFile);
+        BEAST_EXPECT(exists(keyFile));
+
+        {
+            auto const start = testStartRevoke(keyFile, noError, false);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = externalKey.signHex(start);
+            testFinishRevoke(sig, keyFile, noError);
+        }
+        {
+            auto const start = testStartRevoke(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = [&]() {
+                auto sigBlob = strUnHex(externalKey.signHex(start));
+                if (BEAST_EXPECT(sigBlob))
+                    return base64_encode(sigBlob->data(), sigBlob->size());
+                return base64_encode("fail");
+            }();
+            testFinishRevoke(sig, keyFile, noError);
+        }
+
+        {
+            // keys can be revoked multiple times
+            auto const start = testStartRevoke(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = externalKey.signHex(start);
+            testFinishRevoke(sig, keyFile, noError);
+        }
+        {
+            std::string const expectedError = "Manifest is not properly signed";
+            auto const start = testStartRevoke(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = externalKey.sign("foo");
+            testFinishRevoke(sig, keyFile, expectedError);
+        }
+        {
+            std::string const expectedError = "Invalid master signature";
+            auto const start = testStartRevoke(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = "bad signature";
+            testFinishRevoke(sig, keyFile, expectedError);
+        }
+        {
+            // Unlike tokens, which have a random key and a changing sequence,
+            // revocations are fixed, so as long as a valid signature has been
+            // generated, it can be reused. Same idea as how a signed revocation
+            // can be stored and released at any time.
+            // Generate a revocation successfully
+            auto const start = testStartRevoke(keyFile, noError);
+            BEAST_EXPECT(!start.empty());
+            auto const sig = externalKey.signHex(start);
+            testFinishRevoke(sig, keyFile, noError);
+
+            // Reuse the signature.
+            testFinishRevoke(sig, keyFile, noError);
+        }
     }
 
     void
@@ -201,6 +572,59 @@ private:
         };
 
         std::string const data = "data to sign";
+
+        path const subdir = "test_key_file";
+        KeyFileGuard const g(*this, subdir.string());
+        path const keyFile = subdir / "validator_keys.json";
+
+        {
+            std::string const expectedError =
+                "Failed to open key file: " + keyFile.string();
+            testSign(data, keyFile, expectedError);
+        }
+
+        createKeyFile(keyFile);
+        BEAST_EXPECT(exists(keyFile));
+
+        {
+            std::string const emptyData = "";
+            std::string const expectedError =
+                "Syntax error: Must specify data string to sign";
+            testSign(emptyData, keyFile, expectedError);
+        }
+        {
+            std::string const expectedError = "";
+            testSign(data, keyFile, expectedError);
+        }
+    }
+
+    void
+    testHexSign()
+    {
+        testcase("Sign Hex");
+
+        std::stringstream coutCapture;
+        CoutRedirect coutRedirect{coutCapture};
+
+        using namespace boost::filesystem;
+
+        auto testSign = [this](
+                            std::string const& data,
+                            path const& keyFile,
+                            std::string const& expectedError) {
+            try
+            {
+                signHexData(data, keyFile);
+                BEAST_EXPECT(expectedError.empty());
+            }
+            catch (std::exception const& e)
+            {
+                BEAST_EXPECT(e.what() == expectedError);
+            }
+        };
+
+        std::string const rawdata = "data to sign";
+        std::string const data = strHex(rawdata);
 
         path const subdir = "test_key_file";
         KeyFileGuard const g(*this, subdir.string());
@@ -259,6 +683,8 @@ private:
 
         std::vector<std::string> const noArgs;
         std::vector<std::string> const oneArg = {"some data"};
+        std::vector<std::string> const oneHexArg = {strHex(oneArg[0])};
+        std::vector<std::string> const oneDomainArg = {"validator.example.com"};
         std::vector<std::string> const twoArgs = {"data", "more data"};
         std::string const noError = "";
         std::string const argError = "Syntax error: Wrong number of arguments";
@@ -282,6 +708,30 @@ private:
             testCommand(command, twoArgs, keyFile, argError);
         }
         {
+            std::string const command = "set_domain";
+            testCommand(command, noArgs, keyFile, argError);
+            testCommand(command, oneDomainArg, keyFile, noError);
+            testCommand(command, twoArgs, keyFile, argError);
+        }
+        {
+            std::string const command = "attest_domain";
+            testCommand(command, noArgs, keyFile, noError);
+            testCommand(command, oneArg, keyFile, argError);
+            testCommand(command, twoArgs, keyFile, argError);
+        }
+        {
+            std::string const command = "clear_domain";
+            testCommand(command, noArgs, keyFile, noError);
+            testCommand(command, oneArg, keyFile, argError);
+            testCommand(command, twoArgs, keyFile, argError);
+        }
+        {
+            std::string const command = "show_manifest";
+            testCommand(command, noArgs, keyFile, argError);
+            testCommand(command, oneArg, keyFile, noError);
+            testCommand(command, twoArgs, keyFile, argError);
+        }
+        {
             std::string const command = "revoke_keys";
             testCommand(command, noArgs, keyFile, noError);
             testCommand(command, oneArg, keyFile, argError);
@@ -292,6 +742,60 @@ private:
             testCommand(command, noArgs, keyFile, argError);
             testCommand(command, oneArg, keyFile, noError);
             testCommand(command, twoArgs, keyFile, argError);
+        }
+        {
+            std::string const command = "sign_hex";
+            testCommand(command, noArgs, keyFile, argError);
+            testCommand(command, oneHexArg, keyFile, noError);
+            testCommand(command, twoArgs, keyFile, argError);
+        }
+
+        // External signing functionality.
+        std::string const pkArg = [&]() {
+            ValidatorKeys const keys =
+                ValidatorKeys::make_ValidatorKeys(keyFile);
+            return toBase58(TokenType::NodePublic, keys.publicKey());
+        }();
+        {
+            // Purposely shadow "keyFile" from the outer context
+            // to prevent reuse
+            path const keyFile = subdir / "validator_keys_ext.json";
+            // For the functions that expect a signature, don't pass in a
+            // valid signature. This is the error that is returned.
+            std::string const masterKeyError = "Invalid master signature";
+
+            {
+                std::string const command = "create_external";
+                testCommand(command, noArgs, keyFile, argError);
+                testCommand(command, {pkArg}, keyFile, noError);
+                testCommand(command, twoArgs, keyFile, argError);
+            }
+            {
+                std::string const command = "start_token";
+                testCommand(command, noArgs, keyFile, noError);
+                testCommand(command, oneArg, keyFile, argError);
+                testCommand(command, twoArgs, keyFile, argError);
+            }
+            {
+                std::string const command = "finish_token";
+                testCommand(command, noArgs, keyFile, argError);
+                testCommand(command, oneArg, keyFile, masterKeyError);
+                testCommand(command, twoArgs, keyFile, argError);
+            }
+            {
+                std::stringstream ignore;
+                Redirect errRedirect(std::cerr, ignore);
+                std::string const command = "start_revoke_keys";
+                testCommand(command, noArgs, keyFile, noError);
+                testCommand(command, oneArg, keyFile, argError);
+                testCommand(command, twoArgs, keyFile, argError);
+            }
+            {
+                std::string const command = "finish_revoke_keys";
+                testCommand(command, noArgs, keyFile, argError);
+                testCommand(command, oneArg, keyFile, masterKeyError);
+                testCommand(command, twoArgs, keyFile, argError);
+            }
         }
     }
 
@@ -304,7 +808,11 @@ public:
         testCreateKeyFile();
         testCreateToken();
         testCreateRevocation();
+        testCreateKeyFileExternal();
+        testCreateTokenExternal();
+        testCreateRevocationExternal();
         testSign();
+        testHexSign();
         testRunCommand();
     }
 };


### PR DESCRIPTION
This change, if merged, adds support for external signing tools, such as an HSM (Hardware Security Module).

Additionally:
* Include unit tests for external signing support functions
* Because this is a significant change, and this project is not updated often, increment the version number
* Resolves #48

# Outline of steps to use this new functionality:
## One-time setup
1. Obtain the public key of the external tool, it can be encoded in the `rippled` format (e.g. `nHBQi...`), hex encoded, or base-64 encoded. Either way, the key must be 33 bytes decoded, and the first byte must be `0xED` for an `ed25519` key, and `0x02` or `0x03` for a `secp256k1` key.
2. Run `validator-keys create_external <encoded_public_key>`

## Usage
1. Run `validator-keys start_token`. This will return a hex encoded string to sign.
2. Sign the string from step 3 using the external tool. The resulting signature must be hex encoded or base-64 encoded.
3. Run `validator-keys finish_token <encoded_signature>`
4. The result will be a token that can be copied to your `rippled.cfg` file just as if it was generated with `create_token`.

The steps to revoke a key are identical to the Usage steps, except using the `start_revoke_keys` and `finish_revoke_keys` commands.

For testing, if you don't have an HSM handy, you can accomplish the same thing in Usage step 2 using `validator-keys --keyfile <path to a key file generated with create_keys> sign_hex <partial token output from Usage step 1>`