### PR TITLE
[TRIVIAL] Update xrpl version to fix standalone build

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-xrpl/2.1.0
+xrpl/2.3.0-b4
 
 [generators]
 CMakeDeps


### PR DESCRIPTION
* The rest of the code was updated in #54 (89ab7e5) to allow for a combined build for the next version of rippled. Unfortunately, this broke the standalone build. Point conan at the latest beta so the build can work.
* This will need to be updated again after rippled 2.3 is released.

Resolves #55 